### PR TITLE
Use waddstr instead of waddwstr if not defined

### DIFF
--- a/include/utils.h
+++ b/include/utils.h
@@ -80,6 +80,8 @@ namespace utils {
 
     std::wstring toWstring(const std::string &string);
 
+    std::string toString(const std::wstring &wstring);
+
     class WavReader {
     public:
         static std::unique_ptr<char>

--- a/src/Ncurses.cpp
+++ b/src/Ncurses.cpp
@@ -1,14 +1,16 @@
 #include <thread>
+#include <locale>
 
 #include "Ncurses.h"
+#include "utils.h"
 
 
 Ncurses::Ncurses() {
+    setlocale(LC_ALL, "");
     initscr();
     raw();
     noecho();
     curs_set(0);
-    setlocale(LC_ALL, "");
 }
 
 Ncurses::~Ncurses() {
@@ -33,7 +35,11 @@ auto Ncurses::Screen::putLineAt(const std::wstring &string, int y, int x) -> voi
     wmove(window_, y, 0);
     wclrtoeol(window_);
     wmove(window_, y, x);
+#ifdef waddwstr
     waddwstr(window_, string.c_str());
+#else
+    waddstr(window_, utils::toString(string).c_str());
+#endif
     wrefresh(window_);
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -41,6 +41,12 @@ std::wstring utils::toWstring(const std::string &string) {
     return converter.from_bytes(string);
 }
 
+std::string utils::toString(const std::wstring &wstring) {
+    typedef std::codecvt_utf8<wchar_t> convert_type;
+    std::wstring_convert<convert_type, wchar_t> converter;
+    return converter.to_bytes(wstring);
+}
+
 
 std::unique_ptr<char>
 utils::WavReader::loadWAV(const std::string &audioFile, unsigned int &chan, unsigned int &sampleRate, unsigned int &bps,


### PR DESCRIPTION
changelog:
- fallback to normal strings if ncurses doesn't support wchar_t