### PR TITLE
vorbis is also required

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ more information in their docs.
 
 ## Requirements
 - ncurses
+- vorbis
 - OpenAL (For desktop)
 - OpenSLES (For embedded devices)
 


### PR DESCRIPTION
why is vorbis not written as a requirements as it's written in the ```CMakeLists.txt```