### PR TITLE
Handle start signal from hook script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,9 @@ else ()
 
 endif ()
 
+install(PROGRAMS extras/scripts/on-modify.99-tw-pomodoro
+        DESTINATION $ENV{HOME}/.task/hooks/)
+
 install(TARGETS ${PROJECT_NAME}
         RUNTIME DESTINATION bin
         CONFIGURATIONS Release)

--- a/README.md
+++ b/README.md
@@ -60,8 +60,8 @@ order.
 For example:
 
 ```bash
-$ ls -1 ~/.task/hooks/                                                                       │
-on-modify.00-timewarrior                                                                                            │
+$ ls -1 ~/.task/hooks/
+on-modify.00-timewarrior
 on-modify.99-tw-pomodoro
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,12 +12,15 @@ script that integrates it with
 more information in their docs.
 
 ## Requirements
+
 - ncurses
-- vorbis
+- psutil (`sudo pip install psutil` for the hook script)
+- vorbis (For desktop)
 - OpenAL (For desktop)
 - OpenSLES (For embedded devices)
 
 ## Installation
+
 ```bash
 git clone https://github.com/OmarMohamedKhallaf/Timewarrior-Pomodoro.git pomo
 cd pomo
@@ -27,6 +30,7 @@ cmake --build build --parallel 4 --target install
 ```
 
 ## Task lists
+
 - [x] Add sounds after at the end of work and break sessions
 - [x] Parse output from child process
 - [x] Adapt to changes in terminal size
@@ -40,15 +44,37 @@ cmake --build build --parallel 4 --target install
 - [ ] Use ascii art to print digits adapted to the size of the terminal
 
 ## Usage
+
 There are only three commands for now
+
 ```text
 s: to start a session followed by a break
 p: to pause the current session (actually stops it in timewarrior terms)
 e: to exit
 ```
 
+There is a hook scrip that automatically starts tracking by sending a USR1 signal to the program.
+This scrip must be executed after timewarrior hook script, to enforce this ordering they must be named in lexicological
+order.
+
+For example:
+
+```bash
+$ ls -1 ~/.task/hooks/                                                                       │
+on-modify.00-timewarrior                                                                                            │
+on-modify.99-tw-pomodoro
+```
+
+So a normal workflow is like this:
+- you have your tasks stored in taskwarrior
+- you have tw-pomodoro opened in another window, pane, ...
+- you `task 1 start` and tw-pomodoro automatically starts the timer and notifies you at the end of sessions
+- after a break you press `s` and start your next session
+
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 ## License
+
 [GNU General Public License v3.0](https://choosealicense.com/licenses/gpl-3.0/)

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ more information in their docs.
 ```bash
 git clone https://github.com/OmarMohamedKhallaf/Timewarrior-Pomodoro.git pomo
 cd pomo
-# Use -DCMAKE_INSTALL_PREFIX=$PREFIX/usr for termux on android
+# Use -DCMAKE_INSTALL_PREFIX=$PREFIX for termux on android
 cmake -B build -S ./ -DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=Release
 cmake --build build --parallel 4 --target install
 ```
@@ -31,11 +31,12 @@ cmake --build build --parallel 4 --target install
 - [x] Parse output from child process
 - [x] Adapt to changes in terminal size
 - [x] Support unicode
+- [x] Automatic session tracking by handling signals (e.g. from taskwarrior hook scripts)
 - [ ] Handle errors properly (is timew installed ?)
+- [ ] Handle text wrapping properly (automatically calculate starting line to ensure full text is displayed)
 - [ ] Make variables configurable
 - [ ] Confirm exit before exiting
 - [ ] Support for `timew start <tags...>` in the interface
-- [ ] Automatic session tracking by handling signals (e.g. from taskwarrior hook scripts)
 - [ ] Use ascii art to print digits adapted to the size of the terminal
 
 ## Usage

--- a/extras/scripts/on-modify.99-tw-pomodoro
+++ b/extras/scripts/on-modify.99-tw-pomodoro
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import signal
+import sys
+import json
+import psutil
+import signal
+
+try:
+    input_stream = sys.stdin.buffer
+except AttributeError:
+    input_stream = sys.stdin
+
+# Make no changes to the task, simply observe.
+old = json.loads(input_stream.readline().decode("utf-8", errors="replace"))
+new = json.loads(input_stream.readline().decode("utf-8", errors="replace"))
+print(json.dumps(new))
+
+if "start" in new and "start" not in old:
+    for process in psutil.process_iter(["pid", "name"]):
+        if process.name() == "tw-pomodoro":
+            process.send_signal(signal.SIGUSR1)

--- a/extras/scripts/on-modify.99-tw-pomodoro
+++ b/extras/scripts/on-modify.99-tw-pomodoro
@@ -16,6 +16,6 @@ new = json.loads(input_stream.readline().decode("utf-8", errors="replace"))
 print(json.dumps(new))
 
 if "start" in new and "start" not in old:
-    for process in psutil.process_iter(["pid", "name"]):
+    for process in psutil.process_iter(["name"]):
         if process.name() == "tw-pomodoro":
             process.send_signal(signal.SIGUSR1)

--- a/include/utils.h
+++ b/include/utils.h
@@ -13,11 +13,11 @@
 constexpr unsigned int SESSION_TIME_SECS = 25 * 60;
 constexpr unsigned int BREAK_TIME_SECS = 5 * 60;
 
-enum PomodoroSessionType {
+enum SessionType {
     FREE = 1, WORK
 };
 
-enum PomodoroCommandType {
+enum CommandType {
     CONTINUE = 1, QUERY
 };
 
@@ -25,8 +25,8 @@ template<typename Rep, typename Period>
 struct PomodoroSession {
 public:
     std::chrono::duration<Rep, Period> duration;
-    PomodoroSessionType sessionType;
-    PomodoroCommandType commandType;
+    SessionType sessionType;
+    CommandType commandType;
 };
 
 namespace utils {
@@ -40,10 +40,10 @@ namespace utils {
         Queue(Queue &&) = delete;
 
         void push(T x) {
-            std::unique_lock lk(mutex_);
-            queue_.push(x);
-            // Manual unlocking is done before notifying, to avoid waking up the waiting thread only to block again
-            lk.unlock();
+            {
+                std::lock_guard lk(mutex_);
+                queue_.push(x);
+            }// Manual unlocking is done before notifying, to avoid waking up the waiting thread only to block again
             pendingData_.notify_one();
         };
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -17,11 +17,16 @@ enum PomodoroSessionType {
     FREE = 1, WORK
 };
 
+enum PomodoroCommandType {
+    CONTINUE = 1, QUERY
+};
+
 template<typename Rep, typename Period>
 struct PomodoroSession {
 public:
     std::chrono::duration<Rep, Period> duration;
     PomodoroSessionType sessionType;
+    PomodoroCommandType commandType;
 };
 
 namespace utils {

--- a/src/Ncurses.cpp
+++ b/src/Ncurses.cpp
@@ -2,7 +2,6 @@
 #include <locale>
 
 #include "Ncurses.h"
-#include "utils.h"
 
 
 Ncurses::Ncurses() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -11,10 +11,9 @@ static utils::Queue<PomodoroSession<long, std::nano>> taskQueue;
 static std::atomic<bool> isRunning = true;
 static std::atomic<bool> isPause = false;
 
-void usr1SigHandler(int) {
-    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(25), PomodoroSessionType::WORK,
-                    PomodoroCommandType::QUERY});
-    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(5), PomodoroSessionType::FREE});
+auto usr1SigHandler(int) {
+    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(25), SessionType::WORK, CommandType::QUERY});
+    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(5), SessionType::FREE});
     isPause.store(false, std::memory_order_relaxed);    // not used for synchronization
 }
 
@@ -27,7 +26,7 @@ auto main() -> int {
     struct sigaction sa{.sa_flags = SA_RESTART | SA_NOCLDSTOP};
     sa.sa_handler = usr1SigHandler;
     if (sigaction(SIGUSR1, &sa, nullptr) == EINVAL) {
-        cmdScreen.putLineFor(L"Unable to handle signals", cmdScreen.getLines() - 1, cmdScreen.getCols() - 12,
+        cmdScreen.putLineFor(L"Unable to handle signals", cmdScreen.getLines() - 1, cmdScreen.getCols() / 2 - 12,
                              std::chrono::seconds(1));
     }
 
@@ -41,11 +40,11 @@ auto main() -> int {
             auto prevTime{std::chrono::steady_clock::now()};
             std::wstring taskDescription;
 
-            if (task.sessionType == PomodoroSessionType::WORK) {
+            if (task.sessionType == SessionType::WORK) {
                 try {
-                    if (task.commandType == PomodoroCommandType::CONTINUE)
+                    if (task.commandType == CommandType::CONTINUE)
                         taskDescription = utils::executeProcess("/usr/bin/timew", {"continue", nullptr});
-                    else if (task.commandType == PomodoroCommandType::QUERY)
+                    else if (task.commandType == CommandType::QUERY)
                         taskDescription = utils::executeProcess("/usr/bin/timew", {nullptr});
                 } catch (const std::runtime_error &error) {
                     cmdScreen.putLineFor(utils::toWstring(error.what()), cmdScreen.getLines(), 0,
@@ -54,8 +53,8 @@ auto main() -> int {
                 }
             }
             // timer
-            while (task.duration.count() > 0 && isRunning.load(std::memory_order_relaxed) &&
-                   !isPause.load(std::memory_order_relaxed)) {
+            while (isRunning.load(std::memory_order_relaxed) && !isPause.load(std::memory_order_relaxed) &&
+                   task.duration.count() > 0) {
                 // TODO: use ascii art to print digits adapted to the size of the terminal
                 cmdScreen.putLineAt(L"commands: (s)tart, (p)ause, (e)xit", 0, cmdScreen.getCols() / 2 - 17);
                 tmrScreen.putLineAt(utils::formatSeconds<long, std::nano>(task.duration), 1,
@@ -72,7 +71,7 @@ auto main() -> int {
                 prevTime = curTime;
             }
 
-            if (task.sessionType == PomodoroSessionType::WORK) {
+            if (task.sessionType == SessionType::WORK) {
                 try {
                     utils::executeProcess("/usr/bin/timew", {"stop", nullptr});
                 } catch (const std::runtime_error &error) {
@@ -80,7 +79,7 @@ auto main() -> int {
                                          std::chrono::seconds(1));
                 }
                 audioPlayer.play(PROJECT_INSTALL_PREFIX "/share/" PROJECT_NAME "/sounds/Retro_Synth.ogg");
-            } else if (task.sessionType == PomodoroSessionType::FREE) {
+            } else if (task.sessionType == SessionType::FREE) {
                 audioPlayer.play(PROJECT_INSTALL_PREFIX "/share/" PROJECT_NAME "/sounds/Synth_Brass.ogg");
             }
             tmrScreen.clear();
@@ -94,16 +93,16 @@ auto main() -> int {
         switch (cmdChar) {
             case 's':
                 if (taskQueue.empty()) {
-                    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(25), PomodoroSessionType::WORK,
-                                    PomodoroCommandType::CONTINUE});
-                    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(5), PomodoroSessionType::FREE});
+                    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(25), SessionType::WORK,
+                                    CommandType::CONTINUE});
+                    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(5), SessionType::FREE});
                     isPause.store(false, std::memory_order_relaxed);    // not used for synchronization
                 } else {
                     cmdScreen.putLineFor(L"Timer is already running", cmdScreen.getLines(), 0, std::chrono::seconds(1));
                 }
                 break;
             case 'p':
-                isPause = true;
+                isPause.store(true, std::memory_order_relaxed);
                 break;
             case KEY_RESIZE:
                 int lines, cols;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,31 +1,52 @@
 #include <future>
 #include <iostream>
+#include <csignal>
 
 #include "utils.h"
 #include "config.h"
 #include "Ncurses.h"
 #include "sound/AudioPlayer.h"
 
+static utils::Queue<PomodoroSession<long, std::nano>> taskQueue;
+static std::atomic<bool> isRunning = true;
+static std::atomic<bool> isPause = false;
+
+void usr1SigHandler(int) {
+    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(25), PomodoroSessionType::WORK,
+                    PomodoroCommandType::QUERY});
+    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(5), PomodoroSessionType::FREE});
+    isPause.store(false, std::memory_order_relaxed);    // not used for synchronization
+}
+
 auto main() -> int {
     Ncurses ncurses;     // handle initialization of ncurses
     Ncurses::Screen cmdScreen(stdscr);
     Ncurses::Screen tmrScreen(LINES - 2, COLS - 2, 1, 1);
     AudioPlayer audioPlayer;
-    utils::Queue<PomodoroSession<long, std::nano>> taskQueue;
-    std::atomic<bool> isRunning = true;
-    std::atomic<bool> isPause = false;
+
+    struct sigaction sa{.sa_flags = SA_RESTART | SA_NOCLDSTOP};
+    sa.sa_handler = usr1SigHandler;
+    if (sigaction(SIGUSR1, &sa, nullptr) == EINVAL) {
+        cmdScreen.putLineFor(L"Unable to handle signals", cmdScreen.getLines() - 1, cmdScreen.getCols() - 12,
+                             std::chrono::seconds(1));
+    }
 
     std::thread worker([&] {
         audioPlayer.load(PROJECT_INSTALL_PREFIX "/share/" PROJECT_NAME "/sounds/Synth_Brass.ogg");
         audioPlayer.load(PROJECT_INSTALL_PREFIX "/share/" PROJECT_NAME "/sounds/Retro_Synth.ogg");
+
         std::chrono::duration<int, std::nano> delta(0);
-        while (isRunning) {
+        while (isRunning.load(std::memory_order_relaxed)) {
             auto task{taskQueue.pop()};
             auto prevTime{std::chrono::steady_clock::now()};
             std::wstring taskDescription;
+
             if (task.sessionType == PomodoroSessionType::WORK) {
                 try {
-                    taskDescription = utils::executeProcess("/usr/bin/timew", {"continue", nullptr});
+                    if (task.commandType == PomodoroCommandType::CONTINUE)
+                        taskDescription = utils::executeProcess("/usr/bin/timew", {"continue", nullptr});
+                    else if (task.commandType == PomodoroCommandType::QUERY)
+                        taskDescription = utils::executeProcess("/usr/bin/timew", {nullptr});
                 } catch (const std::runtime_error &error) {
                     cmdScreen.putLineFor(utils::toWstring(error.what()), cmdScreen.getLines(), 0,
                                          std::chrono::seconds(1));
@@ -33,7 +54,8 @@ auto main() -> int {
                 }
             }
             // timer
-            while (task.duration.count() > 0 && isRunning && !isPause) {
+            while (task.duration.count() > 0 && isRunning.load(std::memory_order_relaxed) &&
+                   !isPause.load(std::memory_order_relaxed)) {
                 // TODO: use ascii art to print digits adapted to the size of the terminal
                 cmdScreen.putLineAt(L"commands: (s)tart, (p)ause, (e)xit", 0, cmdScreen.getCols() / 2 - 17);
                 tmrScreen.putLineAt(utils::formatSeconds<long, std::nano>(task.duration), 1,
@@ -49,11 +71,13 @@ auto main() -> int {
                 task.duration -= timeSlept;
                 prevTime = curTime;
             }
+
             if (task.sessionType == PomodoroSessionType::WORK) {
                 try {
                     utils::executeProcess("/usr/bin/timew", {"stop", nullptr});
                 } catch (const std::runtime_error &error) {
-                    cmdScreen.putLineFor(utils::toWstring(error.what()), cmdScreen.getLines(), 0, std::chrono::seconds(1));
+                    cmdScreen.putLineFor(utils::toWstring(error.what()), cmdScreen.getLines(), 0,
+                                         std::chrono::seconds(1));
                 }
                 audioPlayer.play(PROJECT_INSTALL_PREFIX "/share/" PROJECT_NAME "/sounds/Retro_Synth.ogg");
             } else if (task.sessionType == PomodoroSessionType::FREE) {
@@ -70,9 +94,10 @@ auto main() -> int {
         switch (cmdChar) {
             case 's':
                 if (taskQueue.empty()) {
-                    isPause = false;
-                    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(25), PomodoroSessionType::WORK});
+                    taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(25), PomodoroSessionType::WORK,
+                                    PomodoroCommandType::CONTINUE});
                     taskQueue.push({std::chrono::duration<long, std::ratio<60, 1>>(5), PomodoroSessionType::FREE});
+                    isPause.store(false, std::memory_order_relaxed);    // not used for synchronization
                 } else {
                     cmdScreen.putLineFor(L"Timer is already running", cmdScreen.getLines(), 0, std::chrono::seconds(1));
                 }
@@ -93,8 +118,8 @@ auto main() -> int {
         flushinp();
     }
 
-    isRunning = false;
     taskQueue.push({});    // necessary since the thread waits on the queue
+    isRunning.store(false, std::memory_order_relaxed);  // not used for synchronization
     worker.join();
 
     return 0;


### PR DESCRIPTION
changelog:
- added a hook script to send a signal to running process named
  "tw-pomodoro"
- query by `timew` only when starting a session by signal, only use
  `timew continue` when starting interactively
- use cmake to install `on-modify.99-tw-pomodoro` to
  `$HOME/.task/hooks/`