### PR TITLE
Continue pomodoro session if already started

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.22)
-project(tw-pomodoro VERSION "2.3.3")
+project(tw-pomodoro VERSION "2.4.0")
 
 configure_file(include/config.h.in config.h)
 set(CMAKE_CXX_STANDARD 20)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ cmake --build build --parallel 4 --target install
 There are only three commands for now
 
 ```text
-s: to start a session followed by a break
+c: to continue a session followed by a break (must be started by taskwarrior & the hook script)
 p: to pause the current session (actually stops it in timewarrior terms)
 e: to exit
 ```

--- a/include/Timew.h
+++ b/include/Timew.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <chrono>
+#include "utils.h"
+
+enum TimewCommand {
+    NONE, START, STOP, RESUME, QUERY
+};
+
+
+template<typename Rep, typename Period>
+struct PomodoroSession {
+    std::chrono::duration<Rep, Period> focusDuration;
+    std::chrono::duration<Rep, Period> breakDuration;
+    TimewCommand timewCommand;
+};
+
+struct TimewQueryResult {
+    std::chrono::seconds trackedTime;
+    std::string taskDescription;
+    bool isTracking;
+};
+
+class Timew {
+public:
+    static utils::ProcessResult start(std::vector<std::string> &tags) noexcept(false) {
+        throw std::logic_error("start not implemented");
+    }
+
+    static utils::ProcessResult stop() noexcept(false) {
+        return utils::executeProcess("/usr/bin/timew", {"stop", ":adjust", nullptr});
+    }
+
+    static utils::ProcessResult resume() noexcept(false) {
+        return utils::executeProcess("/usr/bin/timew", {"continue", nullptr});
+    }
+
+    static TimewQueryResult query() noexcept(false) {
+        auto result{utils::executeProcess("/usr/bin/timew", {nullptr})};
+
+        if (result.exitCode != 0) {
+            return {std::chrono::seconds(0), ""};
+        }
+
+        auto targetIdx{result.output.find("Total")};
+        if (targetIdx == std::string::npos) {
+            throw std::runtime_error("Failed to parse timew command output");
+        }
+
+        targetIdx += 5;     // skip "Total"
+        while (targetIdx < result.output.length() && std::isspace(result.output[targetIdx]))
+            ++targetIdx;
+
+        char *separatorIdx{nullptr};
+        auto hours{std::strtoul(&result.output[targetIdx], &separatorIdx, 10)};
+        auto minutes{std::strtoul(separatorIdx + 1, &separatorIdx, 10)};
+        auto seconds{std::strtoul(separatorIdx + 1, nullptr, 10)};
+
+        return {std::chrono::seconds(hours * 60 * 60 + minutes * 60 + seconds),
+                utils::formatDescription(result.output), result.exitCode == 0};
+    }
+};

--- a/include/utils.h
+++ b/include/utils.h
@@ -12,6 +12,7 @@
 
 #endif
 
+
 namespace utils {
     namespace concurrent {
         /**
@@ -189,24 +190,18 @@ namespace utils {
         };
     };
 
-    enum TimewCommand {
-        NONE, CONTINUE, QUERY
-    };
-
-    template<typename Rep, typename Period>
-    struct PomodoroSession {
-        std::chrono::duration<Rep, Period> focusDuration;
-        std::chrono::duration<Rep, Period> breakDuration;
-        TimewCommand timewCommand;
+    struct ProcessResult {
+        uint8_t exitCode;
+        std::string output;
     };
 
     /**
      * Executes a process and returns stdout or stderr as string
      * @param path The path to the executable
      * @param args The arguments to path to the executable
-     * @return stdout or stderr as a string
+     * @return ProcessResult struct containing the output and the exit code
      */
-    std::string executeProcess(const std::string &path, const std::vector<const char *> &args) noexcept(false);
+    ProcessResult executeProcess(const std::string &path, const std::vector<const char *> &args) noexcept(false);
 
     /**
      * Formats the stdout of timew commands


### PR DESCRIPTION
If the pomodoro session has started by `timew continue` or if the hook script failed to send a signal to `tw-pomodoro` pressing `(c)ontinue` in the interface will automatically calculate the already tracked time and complete the session with the remaining time.

If the already tracked time is greater than the configured session time the session is ended and the break starts.

changelog:
- Timew class to manage the commands
- Fix bug when timew commands throw and isPause flag is not reseted
- Use `(c)ontinue` as command instead of `(s)tart`

closes #15 